### PR TITLE
Updated URLs for the sermon.js page

### DIFF
--- a/Frontend/src/components/Javascript/sermons.js
+++ b/Frontend/src/components/Javascript/sermons.js
@@ -9,7 +9,7 @@ var defaultSermons;
 
 export async function searchByName(){
     var request = new XMLHttpRequest();
-    var url = "http://localhost:8080/api/sermons/search/title/";
+    var url = "https://sacglorychurch.org:8080/api/sermons/search/title/";
     var name = document.getElementById("searchBox").value.replace(" ", "%20");
 
     if(!name){
@@ -34,7 +34,7 @@ export async function searchByName(){
 
 export async function searchByDate(){
     var request = new XMLHttpRequest();
-    var url = "http://sacglorychurch.org:8080/api/sermons/search/date?";
+    var url = "https://sacglorychurch.org:8080/api/sermons/search/date?";
     var startDate = document.getElementById("startDateBox").value;
     var endDate = document.getElementById("endDateBox").value;
     
@@ -76,7 +76,7 @@ export async function searchByDate(){
 
 export async function getSermonById(sermonId){
     try {
-        const response = await fetch(`http://sacglorychurch.org:8080/api/sermons/get/${sermonId}`);
+        const response = await fetch(`https://sacglorychurch.org:8080/api/sermons/get/${sermonId}`);
 
         if(!response.ok){
             console.error(`Error: ${response.status}`);
@@ -149,7 +149,7 @@ export async function showDefaults(){
     }
 
     var request = new XMLHttpRequest();
-    var url = "http://sacglorychurch.org:8080/api/sermons/getDefault";
+    var url = "https://sacglorychurch.org:8080/api/sermons/getDefault";
 
     request.open("GET", url);
     request.send();


### PR DESCRIPTION
I missed this page in my initial sweep. I think this is the only one I missed. Searching for http: doens't return any results in the relevent codebase